### PR TITLE
Create responsive page layout with static-positioning

### DIFF
--- a/css/components/page-parts/_body.scss
+++ b/css/components/page-parts/_body.scss
@@ -1,4 +1,5 @@
 // Body level styling
+$max-width: 1200px !default;
 
 // hits regular pages and generated iframe pages
 body {
@@ -13,7 +14,7 @@ body {
 .ptx-banner,
 .ptx-page,
 .ptx-footer {
-  max-width: 1200px;
+  max-width: $max-width;
   margin-left: auto;
   margin-right: auto;
 }

--- a/css/components/page-parts/_parts-static.scss
+++ b/css/components/page-parts/_parts-static.scss
@@ -62,9 +62,11 @@ body.pretext .ptx-navbar {
   .ptx-toc {
     margin-top: 36px;
     border-right: none;
+    position: sticky;
+    top: $nav-height;
 
     @if $scrolling-toc {
-      scrollbar-width: thin;
+      scrollbar-width: auto;
       scrollbar-color: var(--page-border-color) var(--mainbackground);
     }
 

--- a/css/components/page-parts/_parts-static.scss
+++ b/css/components/page-parts/_parts-static.scss
@@ -1,0 +1,89 @@
+// if page extends a max
+$page-centered: true !default;
+
+$sidebar-width: 240px !default;
+$scrolling-toc: true !default;
+
+$nav-height: 36px !default;
+
+$content-width: 600px !default;
+$content-side-margin: 48px !default;
+$max-width: $content-width + (2 * $content-side-margin) + (2* $sidebar-width);
+
+@use 'body' with ($max-width: 100%);
+@use 'banner';
+
+
+
+@use 'navbar' with (
+  $nav-height: $nav-height,
+);
+
+@use 'toc-default' with (
+  $scrolling: $scrolling-toc,
+  $sidebar-width: $sidebar-width,
+);
+
+@use 'summary-links';
+@use 'footer';
+
+// set these up as CSS variables so they can be modified easily at runtime
+:root {
+  --content-width: min(50vw, #{$content-width});
+  --content-margin: min(10vw, #{$content-side-margin});
+  --right-page-margin: calc((100% - var(--content-width) - 2 * var(--content-margin)) / 2);
+  --max-width: calc(var(--content-width) + 2 * var(--content-margin) + 2 * #{$sidebar-width});
+}
+
+.ptx-masthead .ptx-banner {
+  max-width: var(--max-width);
+  padding: 10px 24px;
+}
+
+.ptx-page {
+  display: flex;
+  max-width: var(--max-width);
+}
+
+body.pretext .ptx-navbar {
+  padding-left: calc((100% - var(--max-width)) / 2);
+  padding-right: calc((100% - var(--max-width)) / 2 + $sidebar-width);
+  // toc-toggle
+  .toc-toggle {
+    gap: 1em;
+  }
+}
+
+// replace the sidebar with a margin matching it's width
+.ptx-sidebar.hidden + .ptx-main {
+    margin-left: min($sidebar-width, var(--right-page-margin));
+  }
+
+  .ptx-toc {
+    margin-top: 36px;
+    border-right: none;
+
+    @if $scrolling-toc {
+      scrollbar-width: thin;
+      scrollbar-color: var(--page-border-color) var(--mainbackground);
+    }
+
+  }
+
+// Base width/margins
+// ptx-main ensures iframe pages don't get these margins
+.ptx-main > .ptx-content {
+  width: var(--content-width);
+  margin: 32px var(--content-margin) 60px;
+}
+
+//// Decrease the side margins once out of room
+//@media screen and (max-width: $content-width + 2 * $content-side-margin) {
+//  .ptx-page > .ptx-main .ptx-content {
+//    margin-left: 28px;
+//    margin-right: 28px;
+//  }
+//  :root {
+//    --content-margin: 28px;
+//  }
+//}

--- a/css/targets/html/paper/shell.scss
+++ b/css/targets/html/paper/shell.scss
@@ -72,8 +72,6 @@ a {
 }
 
 .ptx-runestone-container:has(.parsons_section,.ac_section,.codelens) {
-
-  min-width: 100%;
-  max-width: calc(100% + 128px);
-  margin-left: -64px;
+  width: calc(100% + var(--content-margin));
+  margin-left: calc(-0.5 * var(--content-margin));
 }

--- a/css/targets/html/paper/shell.scss
+++ b/css/targets/html/paper/shell.scss
@@ -1,23 +1,18 @@
-$text-width: 600px;
-$text-side-padding: 120px;
-$content-width: $text-width + (2 * $text-side-padding);
-$sidebar-width: 240px;
-$sidebar-margin-left: 24px;
-$side-width: $sidebar-width +  $sidebar-margin-left;
-//$max-width: 1200px;
-$max-width: $content-width + (2* $side-width);
+$content-width: 600px;
+$content-side-padding: 120px;
+//$content-width: $text-width + (2 * $text-side-padding);
+//$sidebar-width: 240px;
 
-//$content-margins: calc((100% - $content-width) / 2);
 $scrolling-toc: true;
 $nav-height: 36px;
 
 @use 'components/helpers/buttons-default' as buttons;
 
-@use 'components/page-parts/parts-default' with(
+@use 'components/page-parts/parts-static' with(
   $page-centered: true,
   $scrolling-toc: $scrolling-toc,
-  $content-width: $text-width,
-  $content-side-margin: $text-side-padding
+  $content-width: $content-width,
+  $content-side-margin: $content-side-padding
 );
 
 // help links stick out
@@ -30,86 +25,18 @@ a {
   background: unset;
 }
 
-.ptx-masthead .ptx-banner {
-  //max-width: unset;
-  max-width: $max-width;
-  padding: 10px 24px;
-}
-
-.ptx-page {
-  display: flex;
-  max-width: $max-width;
-}
 
 .ptx-main {
-  display: block;
-  position: relative;
-  margin-left: 0;
-  padding: 0;
-  max-width: $content-width;
   box-shadow: 10px 15px 40px -20px var(--assembborder);
 }
 
-@media screen and (min-width: 1200px) {
-  body.pretext .ptx-navbar {
-
-      //padding-left:  calc($sidebar-width + max(2%, calc($margins - $sidebar-width)));
-      padding: 0 calc((100% - $content-width) / 2);
-      //padding-right: calc(100% - $content-width - $sidebar-width - max(2%, calc($margins - $sidebar-width)));
-      // toc-toggle
-      .toc-toggle {
-        position: absolute;
-        left: calc((100% - $max-width) / 2);
-        margin-left: $sidebar-margin-left;
-        top: 0;
-        gap: 1em;
-      }
-  }
-}
-
-.ptx-sidebar.hidden + .ptx-main {
-  margin-left: $side-width;
-}
-
-.ptx-sidebar {
-  top: 0;
-  left: 0;
-  margin-left: $sidebar-margin-left;
-  position: relative;
-  display: block;
-}
-
-.ptx-sidebar::after {
-  content: "";
-  top: 0;
-  left: 0;
-  height: 48px;
-  right: 0;
-  background: linear-gradient(to bottom, var(--mainbackground) 25%, #ffffff00 100%);
-  position: absolute;
-}
-
 .ptx-toc {
-  padding-top: $nav-height;
-  border-right: 2px solid var(--mainbackground);
-  position: sticky;
-  top: $nav-height;
   background-color: var(--mainbackground);
-
-  @if $scrolling-toc {
-    scrollbar-width: thin;
-    scrollbar-color: var(--page-border-color) var(--mainbackground);
-  }
-
   .toc-item {
     background-color: var(--mainbackground);
   }
 }
 
-
-//.ptx-toc.focused {
-//  padding-top: 10px
-//}
 
 .ptx-toc.focused .toc-expander {
   padding: 2px 0 2px 5px;

--- a/css/targets/html/paper/theme-paper.scss
+++ b/css/targets/html/paper/theme-paper.scss
@@ -19,7 +19,6 @@ $background-color-dark: #23241f !default;
 @use 'components/pretext';
 @use 'shell';
 @use 'heading-tweaks';
-@use 'components/page-parts/parts-default';
 @use 'components/chunks/chunks-minimal';
 
 //@use 'heading-tweaks';

--- a/script/cssbuilder/cssbuilder.mjs
+++ b/script/cssbuilder/cssbuilder.mjs
@@ -115,6 +115,7 @@ function getTargets(options) {
     { out: 'theme-centered-wide', in: path.join(cssRoot, 'targets/html/centered-wide/theme-centered-wide.scss')},
     { out: 'theme-denver', in: path.join(cssRoot, 'targets/html/denver/theme-denver.scss') },
     { out: 'theme-tacoma', in: path.join(cssRoot, 'targets/html/tacoma/theme-tacoma.scss') },
+    { out: 'theme-paper', in: path.join(cssRoot, 'targets/html/paper/theme-paper.scss') },
     // -------------------------------------------------------------------------
     // -------------------------------------------------------------------------
     // Other modules - these are individually and conditionally loaded on pretext pages


### PR DESCRIPTION
This redoes the `paper` theme the right way: I created a new `page-parts/parts-static.scss` that does what `page-parts/parts-default` was doing, but where toggling the table of contents doesn't  move the rest of the page content (unless doing so would recenter that content on narrow views).

Also, through css min() calculations, the margins and content shrinks appropriately as the view decreases.  

This might be worth implementing more broadly, though I'm curious what other approaches are possible in your centered wide theme.